### PR TITLE
1.10.1

### DIFF
--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -123,4 +123,102 @@ class Tests: XCTestCase {
         // Sanity: the body still has its own url; we're just not surfacing it via clickedUrl.
         XCTAssertEqual(notification.url, "https://example.com/body")
     }
+
+    // MARK: - API.getInAppMessages crash regression
+    //
+    // These specs prove the SDK no longer trips `fatalError("Unreachable")` when `Request.post`
+    // legitimately callbacks `(result: nil, error: nil)`. If a future change re-introduces a
+    // fatalError on this path the XCTest runner itself crashes — so these tests double as a
+    // hard guarantee that the in-app message fetcher cannot tear down the host app.
+
+    func testGetInAppMessages_failsGracefullyOnMalformedBody() {
+        // Request.swift:113-117 — `JSONSerialization.isValidJSONObject(body)` returns false for
+        // NaN/Infinity, so `getRequestWithBody` is nil and `Request.post` calls `completion(nil, nil)`
+        // synchronously. Previously crashed via fatalError; now resolves to .failure.
+        Globals.projectIdInUserDefaults = "test-project-id"
+        defer { Globals.projectIdInUserDefaults = nil }
+
+        let exp = expectation(description: "completion invoked")
+        var captured: Result<[String: Any], Error>?
+
+        API.shared.getInAppMessages(
+            deviceId: "device-1",
+            group: "default",
+            data: ["bad": Double.nan]
+        ) { result in
+            captured = result
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 2.0)
+        guard case let .failure(error) = captured else {
+            XCTFail("expected failure, got \(String(describing: captured))")
+            return
+        }
+        guard case Request.HTTPError.unexpectedNilResponse = error else {
+            XCTFail("expected HTTPError.unexpectedNilResponse, got \(error)")
+            return
+        }
+    }
+
+    func testGetInAppMessages_failsGracefullyOnNonJSON200Body() {
+        // Request.swift:131-137 — a 200 response whose body isn't JSON makes `Request.post`
+        // call `completion(nil, nil)`. Previously crashed via fatalError; now resolves to .failure.
+        Globals.projectIdInUserDefaults = "test-project-id"
+        defer { Globals.projectIdInUserDefaults = nil }
+
+        URLProtocol.registerClass(NonJSON200ResponseStub.self)
+        defer { URLProtocol.unregisterClass(NonJSON200ResponseStub.self) }
+
+        let exp = expectation(description: "completion invoked")
+        var captured: Result<[String: Any], Error>?
+
+        API.shared.getInAppMessages(
+            deviceId: "device-1",
+            group: "default",
+            data: nil
+        ) { result in
+            captured = result
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 5.0)
+        guard case let .failure(error) = captured else {
+            XCTFail("expected failure, got \(String(describing: captured))")
+            return
+        }
+        guard case Request.HTTPError.unexpectedNilResponse = error else {
+            XCTFail("expected HTTPError.unexpectedNilResponse, got \(error)")
+            return
+        }
+    }
+}
+
+// URLSession.shared honors URLProtocol subclasses registered via `URLProtocol.registerClass`,
+// which lets us intercept the FlareLane service host and return a non-JSON 200 body without
+// touching `Request`'s internals.
+private final class NonJSON200ResponseStub: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "service-api.flarelane.com"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "text/html"]
+              ) else {
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("<html>not-json</html>".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }

--- a/FlareLane.podspec
+++ b/FlareLane.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'FlareLane'
-  s.version          = '1.10.0'
+  s.version          = '1.10.1'
   s.summary          = 'FlareLane iOS SDK'
 
   s.homepage         = 'https://github.com/flarelane/FlareLane-iOS-SDK'

--- a/Sources/FlareLaneSwift/API.swift
+++ b/Sources/FlareLaneSwift/API.swift
@@ -136,9 +136,15 @@ final class API {
       }
       if let result {
         completionHandler(.success(result))
-      } else {
-        fatalError("Unreachable")
+        return
       }
+      // (result, error) == (nil, nil) is reachable: request build failure,
+      // a 200 response whose body isn't JSON, or a URLSession completion that
+      // delivers data=nil/error=nil under background + low-memory pressure
+      // (observed on iOS 26 / iPhone 13 Pro Max). Fail gracefully instead of
+      // crashing the host app.
+      Logger.error("getInAppMessages: nil response with no error")
+      completionHandler(.failure(Request.HTTPError.unexpectedNilResponse))
     }
   }
 }

--- a/Sources/FlareLaneSwift/Globals.swift
+++ b/Sources/FlareLaneSwift/Globals.swift
@@ -14,7 +14,7 @@ public enum SdkType: String {
 }
 
 final class Globals {
-  static var sdkVersion = "1.10.0"
+  static var sdkVersion = "1.10.1"
   static var sdkType: SdkType = .native
   static var sdkPlatform = "ios"
   

--- a/Sources/FlareLaneSwift/Request.swift
+++ b/Sources/FlareLaneSwift/Request.swift
@@ -18,6 +18,10 @@ final class Request {
   enum HTTPError: Error {
     case transportError(Error)
     case serverSideError(Int)
+    /// URLSession callback delivered no data and no error, or the 200 body wasn't JSON.
+    /// Observed on iOS under background + low-memory pressure where the system
+    /// terminates an in-flight dataTask without surfacing an NSURLError.
+    case unexpectedNilResponse
   }
   
   func getBaseURL () -> String? {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 일부 요청에서 응답이 비어 있거나 JSON으로 해석되지 않는 경우에도 앱이 중단되지 않고, 오류로 안전하게 처리되도록 개선했습니다.
  * 인앱 메시지 조회 흐름의 예외 처리 안정성이 향상되었습니다.

* **Tests**
  * 위 상황을 재현하는 회귀 테스트가 추가되어, 동일 문제가 다시 발생하지 않도록 검증을 강화했습니다.

* **Chores**
  * SDK 버전이 `1.10.1`로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->