### PR TITLE
1.10.2

### DIFF
--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -222,3 +222,104 @@ private final class NonJSON200ResponseStub: URLProtocol {
 
     override func stopLoading() {}
 }
+
+// MARK: - InAppMessageService completion contract
+//
+// showInAppMessageIfNeeded MUST invoke its completion exactly once on every exit path so the
+// FlareLaneTaskManager slot is released without waiting for its TIMEOUT_MS (10s). These specs
+// pin that contract; a regression here re-introduces the "next displayInApp takes 10s" bug
+// reported in production.
+
+extension Tests {
+
+    func testShowInAppMessageIfNeeded_callsCompletionWhenDeviceIdMissing() {
+        Globals.deviceIdInUserDefaults = nil
+
+        let exp = expectation(description: "completion invoked (device-id guard)")
+        var callCount = 0
+        InAppMessageService.shared.showInAppMessageIfNeeded(group: "TabHome", data: nil) {
+            callCount += 1
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 2.0)
+        XCTAssertEqual(callCount, 1)
+    }
+
+    func testShowInAppMessageIfNeeded_callsCompletionOnAPIFailure() {
+        // Emulate the bug reproducer: the API responds with a 200 body that isn't JSON, which
+        // Request.post surfaces as `.failure(unexpectedNilResponse)`. Our fix routes the failure
+        // through `completion()` instead of dropping the callback silently.
+        Globals.projectIdInUserDefaults = "test-project-id"
+        Globals.deviceIdInUserDefaults = "device-1"
+        defer {
+            Globals.projectIdInUserDefaults = nil
+            Globals.deviceIdInUserDefaults = nil
+        }
+
+        URLProtocol.registerClass(NonJSON200ResponseStub.self)
+        defer { URLProtocol.unregisterClass(NonJSON200ResponseStub.self) }
+
+        let exp = expectation(description: "completion invoked (API failure)")
+        var callCount = 0
+        InAppMessageService.shared.showInAppMessageIfNeeded(group: "TabHome", data: nil) {
+            callCount += 1
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 5.0)
+        XCTAssertEqual(callCount, 1)
+    }
+
+    func testShowInAppMessageIfNeeded_callsCompletionOnEmptyDataArray() {
+        // Success response with `data: []` — the "no displayable IAM" branch. Must still
+        // release the task slot; otherwise the next displayInApp waits for TIMEOUT_MS.
+        Globals.projectIdInUserDefaults = "test-project-id"
+        Globals.deviceIdInUserDefaults = "device-1"
+        defer {
+            Globals.projectIdInUserDefaults = nil
+            Globals.deviceIdInUserDefaults = nil
+        }
+
+        URLProtocol.registerClass(EmptyDataArrayResponseStub.self)
+        defer { URLProtocol.unregisterClass(EmptyDataArrayResponseStub.self) }
+
+        let exp = expectation(description: "completion invoked (empty data)")
+        var callCount = 0
+        InAppMessageService.shared.showInAppMessageIfNeeded(group: "TabHome", data: nil) {
+            callCount += 1
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 5.0)
+        XCTAssertEqual(callCount, 1)
+    }
+}
+
+// Returns a well-formed but empty IAM response body so the caller reaches the "nothing to
+// show" branch without touching UIKit.
+private final class EmptyDataArrayResponseStub: URLProtocol {
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "service-api.flarelane.com"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+              ) else {
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("{\"data\":[]}".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/FlareLane.podspec
+++ b/FlareLane.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'FlareLane'
-  s.version          = '1.10.1'
+  s.version          = '1.10.2'
   s.summary          = 'FlareLane iOS SDK'
 
   s.homepage         = 'https://github.com/flarelane/FlareLane-iOS-SDK'

--- a/Sources/FlareLaneSwift/FlareLane.swift
+++ b/Sources/FlareLaneSwift/FlareLane.swift
@@ -253,8 +253,11 @@ import UIKit
   @objc public static func displayInApp(group: String, data: [String: Any]? = nil) {
     inAppMessageThrottler.throttle {
       taskManager.addTaskAfterInit(taskName: "displayInApp") { completionTask in
-        InAppMessageService.shared.showInAppMessageIfNeeded(group: group, data: data)
-        completionTask()
+        // Wait for the fetch/display flow to finish before releasing the queue slot;
+        // otherwise a follow-up displayInApp() can race the in-flight HTTP response.
+        InAppMessageService.shared.showInAppMessageIfNeeded(group: group, data: data) {
+          completionTask()
+        }
       }
     }
   }

--- a/Sources/FlareLaneSwift/Globals.swift
+++ b/Sources/FlareLaneSwift/Globals.swift
@@ -14,7 +14,7 @@ public enum SdkType: String {
 }
 
 final class Globals {
-  static var sdkVersion = "1.10.1"
+  static var sdkVersion = "1.10.2"
   static var sdkType: SdkType = .native
   static var sdkPlatform = "ios"
   

--- a/Sources/FlareLaneSwift/InAppMessageService.swift
+++ b/Sources/FlareLaneSwift/InAppMessageService.swift
@@ -19,24 +19,31 @@ final class InAppMessageService {
 
   private init() {}
 
-  func showInAppMessageIfNeeded(group: String, data: [String: Any]?) {
+  /// Fetches and displays an in-app message for the given group.
+  /// - Parameter completion: Invoked exactly once when the fetch/display flow finishes,
+  ///   regardless of success, failure, or guard early-return. Callers rely on this to
+  ///   release the FlareLaneTaskManager slot without waiting for its timeout.
+  func showInAppMessageIfNeeded(group: String, data: [String: Any]?, completion: @escaping () -> Void) {
     guard let deviceId = Globals.deviceIdInUserDefaults else {
       Logger.error("deviceId does not set.")
+      completion()
       return
     }
 
     if isDisplaying {
       Logger.verbose("InAppMessage is already displaying")
+      completion()
       return
     }
 
-    API.shared.getInAppMessages(deviceId: deviceId, group: group, data: data) { result in
+    API.shared.getInAppMessages(deviceId: deviceId, group: group, data: data) { [weak self] result in
       switch result {
       case let .success(data):
-        self.processInAppMessages(data: data)
+        self?.processInAppMessages(data: data)
       case let .failure(error):
         Logger.error("Failed to get in app messages.", error: error)
       }
+      completion()
     }
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 인앱 메시지 표시 요청이 성공하거나 실패하거나 표시할 메시지가 없는 경우에도 완료 처리가 정상적으로 실행됩니다.
  * 기기 정보가 없거나 이미 메시지를 표시 중인 상황에서도 요청이 중단되지 않고 안정적으로 종료됩니다.
  * 네트워크 응답 처리 중 객체 해제 상황의 안정성이 개선되었습니다.

* **기타**
  * SDK 버전이 1.10.2로 업데이트되었습니다.
  * 인앱 메시지 요청 완료 동작에 대한 회귀 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->